### PR TITLE
Mark as compatible with Celery 5.1.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: "Run tox targets for ${{ matrix.python-version }}"
         env:
-          TOXENV: "${{ matrix.python-version }}-celery44,${{ matrix.python-version }}-celery50"
+          TOXENV: "${{ matrix.python-version }}-celery44,${{ matrix.python-version }}-celery50,${{ matrix.python-version }}-celery51"
         run: "python -m tox"
 
       - name: "Run tox targets for ${{ matrix.python-version }} for celery master"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     url='https://github.com/clokep/celery-batches',
     license='BSD',
     platforms=['any'],
-    install_requires=['celery>=4.4,<5.1'],
+    install_requires=['celery>=4.4,<5.2'],
     python_requires=">=3.6,",
     classifiers=[
         'Development Status :: 3 - Alpha',
@@ -37,6 +37,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {pypy3,3.6,3.7,3.8,3.9}-celery{44,50,master}
+    {pypy3,3.6,3.7,3.8,3.9}-celery{44,50,51,master}
     flake8
 
 [testenv]
@@ -8,6 +8,7 @@ deps=
     -r{toxinidir}/requirements/test.txt
     celery44: celery>=4.4,<4.5
     celery50: celery>=5.0,<5.1
+    celery51: celery>=5.1.0b2,<5.2
     celerymaster: https://codeload.github.com/celery/celery/zip/master
 
     flake8: -r{toxinidir}/requirements/pkgutils.txt


### PR DESCRIPTION
Celery 5.1 beta 2 is out, so we should check against this.