### PR TITLE
Fix an issue with Celery 5.1.0 and storing results.

### DIFF
--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -46,4 +46,4 @@ def cumadd(requests):
     result = 0
     for request in requests:
         result += request.args[0]
-        current_app.backend.mark_as_done(request.id, result)
+        current_app.backend.mark_as_done(request.id, result, request=request)


### PR DESCRIPTION
This fixes an error on Celery 5.1.0 and storing results (when passing the `request` object):

```
AttributeError: 'SimpleRequest' object has no attribute 'ignore_result'
```

This adds compatibility with celery/celery#6713.