### PR TITLE
Do not error if passing multiple args or kwargs to the batch task.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,12 @@
 Changelog
 #########
 
+next
+====
+
+* Support passing multiple or keyword arguments disabling Celery's ``typing``
+  feature for ``Batch`` tasks. (`#39 <https://github.com/clokep/celery-batches/pull/39>`_)
+
 0.6 2021-12-30
 ==============
 

--- a/celery_batches/__init__.py
+++ b/celery_batches/__init__.py
@@ -200,6 +200,14 @@ class SimpleRequest:
 class Batches(Task):
     abstract = True
 
+    # Disable typing since the signature of batch tasks take only a single item
+    # (the list of SimpleRequest objects), but when calling it it should be
+    # possible to provide more arguments.
+    #
+    # This unfortunately pushes more onto the user to ensure that each call to
+    # a batch task is using the expected signature.
+    typing = False
+
     #: Maximum number of message in buffer.
     flush_every = 10
 

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -32,7 +32,7 @@ def add(requests):
     """Add the first argument of each call."""
     result = 0
     for request in requests:
-        result += request.args[0]
+        result += sum(request.args) + sum(request.kwargs.values())
 
     Results().set(result)
     return result

--- a/t/integration/test_batches.py
+++ b/t/integration/test_batches.py
@@ -68,6 +68,28 @@ def test_apply():
     assert Results().get() == 1
 
 
+def test_multi_arg(celery_worker):
+    """The batch task runs after two calls."""
+    add.delay(1, 2)
+    add.delay(3, 4)
+
+    # Let the worker work.
+    _wait_for_ping()
+
+    assert Results().get() == 10
+
+
+def test_kwarg(celery_worker):
+    """The batch task runs after two calls."""
+    add.delay(a=1, b=2)
+    add.delay(a=3, b=4)
+
+    # Let the worker work.
+    _wait_for_ping()
+
+    assert Results().get() == 10
+
+
 def test_flush_interval(celery_worker):
     """The batch task runs after the flush interval has elapsed."""
     add.delay(1)


### PR DESCRIPTION
Fixes #38.