### PR TITLE
`.gitignore`: Ignore virtualenvs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ htmlcov
 # Editor related.
 .idea
 .python-version
+
+# virtualenvs
+.*env*/


### PR DESCRIPTION
`.*env*` catches `.env`, `.env3`, `.venv`, `.venv3`, `.venv310`, etc