### PR TITLE
Run tests against live brokers (RabbitMQ & Redis)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,5 @@ jobs:
 
       - name: "Run tox targets"
         env:
-          TOX_SKIP_ENV: ".*celery[^5][^2].*"
-          TEST_BROKER: redis://
-          TEST_BACKEND: redis://
+          TOX_SKIP_ENV: ".*-[^i].*"
         run: "python -m tox"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
         image: rabbitmq
         # Set health checks to wait until redis has started
         options: >-
-          --health-cmd "redis-cli ping"
+          --health-cmd "rabbitmq-diagnostics -q status"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,10 +50,20 @@ jobs:
         continue-on-error: true
 
   integration-tests:
-    name: "Latest Python + latest Celery + Redis"
+    name: "Integration tests"
     runs-on: ubuntu-latest
 
     services:
+      rabbitmq:
+        image: rabbitmq
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5672:5672
       redis:
         image: redis
         # Set health checks to wait until redis has started

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,12 +40,12 @@ jobs:
 
       - name: "Run tox targets for ${{ matrix.python-version }}"
         env:
-          TOX_SKIP_ENV: ".*celerymaster.*"
+          TOX_SKIP_ENV: ".*celerymaster.*|.*integration.*"
         run: "python -m tox"
 
       - name: "Run tox targets for ${{ matrix.python-version }} for celery master"
         env:
-          TOX_SKIP_ENV: ".*celery[^m].*"
+          TOX_SKIP_ENV: ".*celery[^m].*|.*integration.*"
         run: "python -m tox"
         continue-on-error: true
 
@@ -80,5 +80,5 @@ jobs:
 
       - name: "Run tox targets"
         env:
-          TOX_SKIP_ENV: ".*-[^i].*"
+          TOX_SKIP_ENV: ".*unit.*|flake8"
         run: "python -m tox"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,3 +48,39 @@ jobs:
           TOX_SKIP_ENV: ".*celery[^m].*"
         run: "python -m tox"
         continue-on-error: true
+
+  integration-tests:
+    name: "Latest Python + latest Celery + Redis"
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.x"
+
+      - name: "Install dependencies"
+        run: |
+          set -xe
+          python -VV
+          python -m site
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade tox tox-gh-actions
+
+      - name: "Run tox targets"
+        env:
+          TOX_SKIP_ENV: ".*celery[^5][^2].*"
+          TEST_BROKER: redis://
+          TEST_BACKEND: redis://
+        run: "python -m tox"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,8 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        ports:
+          - 6379:6379
 
     steps:
       - uses: actions/checkout@v2

--- a/t/integration/conftest.py
+++ b/t/integration/conftest.py
@@ -1,11 +1,16 @@
+import os
+
 import pytest
+
+TEST_BROKER = os.environ.get('TEST_BROKER', 'memory://')
+TEST_BACKEND = os.environ.get('TEST_BACKEND', 'cache+memory://')
 
 
 @pytest.fixture(scope='session', params=[1, 2])
 def celery_config(request):
     return {
-        'broker_url': 'memory://',
-        'result_backend': 'cache+memory://',
+        'broker_url': TEST_BROKER,
+        'result_backend': TEST_BACKEND,
         # Test both protocol 1 and 2 via the parameterized fixture.
         'task_protocol': request.param,
     }

--- a/t/integration/test_batches.py
+++ b/t/integration/test_batches.py
@@ -67,8 +67,8 @@ def test_apply():
 def test_flush_interval(celery_app, celery_worker):
     """The batch task runs after the flush interval has elapsed."""
 
-    if celery_app.conf.broker_url.startswith('redis'):
-        raise pytest.skip('Flaky on redis')
+    if not celery_app.conf.broker_url.startswith('memory'):
+        raise pytest.skip('Flaky on live brokers')
 
     result = add.delay(1)
 

--- a/t/integration/test_batches.py
+++ b/t/integration/test_batches.py
@@ -64,8 +64,12 @@ def test_apply():
     assert result.get() == 1
 
 
-def test_flush_interval(celery_worker):
+def test_flush_interval(celery_app, celery_worker):
     """The batch task runs after the flush interval has elapsed."""
+
+    if celery_app.conf.broker_url.startswith('redis'):
+        raise pytest.skip('Flaky on redis')
+
     result = add.delay(1)
 
     # The flush interval is 1 second, this is longer.

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,7 @@
 envlist =
     {pypy3,3.7,3.8,3.9}-celery{44,50,51,52,master},
     # Celery 5.2 added support for Python 3.10.
-    3.10-celery{52,master},
-    # Test against live brokers, but only once.
-    3.10-celery52-{rabbitmq,redis},
+    3.10-celery{52,master}
     flake8
 isolated_build = True
 
@@ -35,12 +33,6 @@ recreate = False
 commands =
     coverage run -m pytest
     coverage html
-setenv =
-    rabbitmq: TEST_BROKER=amqp://
-    rabbitmq: TEST_BACKEND=rpc://
-
-    redis: TEST_BROKER=redis://
-    redis: TEST_BACKEND=redis://
 
 [testenv:flake8]
 basepython = python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ envlist =
     {pypy3,3.7,3.8,3.9}-celery{44,50,51,52,master},
     # Celery 5.2 added support for Python 3.10.
     3.10-celery{52,master},
+    # Test against live brokers, but only once.
+    3.10-celery52-redis,
     flake8
 isolated_build = True
 
@@ -24,12 +26,18 @@ deps=
     celery52: celery>=5.2.0b3,<5.3
     celerymaster: https://codeload.github.com/celery/celery/zip/master
 
+    # By default celery (via kombu) install py-amqp.
+    redis: celery[redis]
+
     flake8: -r{toxinidir}/requirements/pkgutils.txt
 sitepackages = False
 recreate = False
 commands =
     coverage run -m pytest
     coverage html
+setenv =
+    redis: TEST_BROKER=redis://
+    redis: TEST_BACKEND=redis://
 
 [testenv:flake8]
 basepython = python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     # Celery 5.2 added support for Python 3.10.
     3.10-celery{52,master}-unit,
     # Integration tests.
-    3.10-celery52-integration-redis
+    3.10-celery52-integration-redis,
     flake8
 isolated_build = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     # Celery 5.2 added support for Python 3.10.
     3.10-celery{52,master},
     # Test against live brokers, but only once.
-    3.10-celery52-redis,
+    3.10-celery52-{rabbitmq,redis},
     flake8
 isolated_build = True
 
@@ -36,6 +36,9 @@ commands =
     coverage run -m pytest
     coverage html
 setenv =
+    rabbitmq: TEST_BROKER=amqp://
+    rabbitmq: TEST_BACKEND=rpc://
+
     redis: TEST_BROKER=redis://
     redis: TEST_BACKEND=redis://
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     # Celery 5.2 added support for Python 3.10.
     3.10-celery{52,master}-unit,
     # Integration tests.
-    3.10-celery52-integration-redis,
+    3.10-celery52-integration-{rabbitmq,redis},
     flake8
 isolated_build = True
 
@@ -38,6 +38,9 @@ commands =
 setenv =
     redis: TEST_BROKER=redis://
     redis: TEST_BACKEND=redis://
+
+    rabbitmq: TEST_BROKER=pyamqp://
+    rabbitmq: TEST_BACKEND=rpc
 
 [testenv:flake8]
 basepython = python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,10 @@
 [tox]
 envlist =
-    {pypy3,3.7,3.8,3.9}-celery{44,50,51,52,master},
+    {pypy3,3.7,3.8,3.9}-celery{44,50,51,52,master}-unit,
     # Celery 5.2 added support for Python 3.10.
-    3.10-celery{52,master}
+    3.10-celery{52,master}-unit,
+    # Integration tests.
+    3.10-celery52-integration-redis
     flake8
 isolated_build = True
 
@@ -33,6 +35,9 @@ recreate = False
 commands =
     coverage run -m pytest
     coverage html
+setenv =
+    redis: TEST_BROKER=redis://
+    redis: TEST_BACKEND=redis://
 
 [testenv:flake8]
 basepython = python3.7


### PR DESCRIPTION
* Configures pytest / tox / GitHub Actions to run against a live RabbitMQ or Redis broker for tests.
* Skips 1 test which is failing against live brokers.