### PR TITLE
Added support for requests that contain an ETA datetime in the future

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -93,6 +93,23 @@ Using the API is done as follows::
         from celery import current_app
         current_app.backend.mark_as_done(request.id, response, request=request)
 
+.. note::
+
+    The use of ``current_app.backend.mark_as_retry()`` and ``current_app.backend.mark_as_failure()`` are not currently supported.
+    If task retry on failure is required, the following workaround may be suitable:
+
+        @app.task(base=Batches, flush_every=100, flush_interval=10)
+        def wot_api(requests):
+            # Do things that might fail
+            # responses = [...]
+
+            for response, request in zip(reponses, requests):
+                if response is True:
+                    app.backend.mark_as_done(request.id, response, request=request)
+                else:
+                    # Retry a new task with the same arguments 10 seconds from now
+                    wot_api.apply_async(args=request.args, kwargs=request.kwargs, countdown=10)
+
 .. toctree::
    :hidden:
 

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -31,3 +31,18 @@ def cumadd(requests):
     for request in requests:
         result += request.args[0]
         current_app.backend.mark_as_done(request.id, result, request=request)
+
+@shared_task(base=Batches, flush_every=2, flush_interval=1)
+def retry_if_even(requests):
+    """Retry the task if the first argument of a request is even."""
+    from celery import current_app
+
+    for request in requests:
+        if request.args[0] % 2 == 1:
+            # Odd, success
+            current_app.backend.mark_as_done(request.id, True, request=request)
+        else:
+            # Even, so modify to be odd next time around and retry
+            current_app.backend.mark_as_failure(request.id, False)
+            request.args[0] += 1
+            retry_if_even.apply_async(args=request.args, kwargs=request.kwargs, countdown=3)


### PR DESCRIPTION
Hello,

I'm using celery-batches for a project that requires failed tasks to be retried at a later time (for example, if a web API request fails). I documented the approach that I was hoping to use in the case of failure and retry (`apply_async(countdown=10)`) in this pull request, which was inspired by the discussion in issue #10. I noticed that the approach did not work, because celery-batches@0.6 does not handle Celery Request objects that have an `.eta` field. I've added support to celery-batches for handling this scenario, and I hope that you will consider merging my changes into the main branch for inclusion in an upcoming 0.7 release.

Thank you.