### PR TITLE
Reduce the flush interval in tests.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,8 @@ Maintenance
 
 * Fix running of tests via tox. (`#40 <https://github.com/clokep/celery-batches/pull/40>`_,
   `#58 <https://github.com/clokep/celery-batches/pull/58>`_)
-* Simplify tests. (`#56 <https://github.com/clokep/celery-batches/pull/56>`_)
+* Simplify tests. (`#56 <https://github.com/clokep/celery-batches/pull/56>`_,
+  `#60 <https://github.com/clokep/celery-batches/pull/60>`_)
 * Improve PyPI metadata. (`#43 <https://github.com/clokep/celery-batches/pull/43>`_,
   `#52 <https://github.com/clokep/celery-batches/pull/52>`_)
 * Ignore virtualenvs in `.gitignore`. Contributed by `Tony Narlock <https://github.com/tony>`_.

--- a/t/integration/tasks.py
+++ b/t/integration/tasks.py
@@ -6,9 +6,13 @@ from celery_batches import Batches
 logger = get_task_logger(__name__)
 
 
-@shared_task(base=Batches, flush_every=2, flush_interval=1)
+@shared_task(base=Batches, flush_every=2, flush_interval=0.1)
 def add(requests):
-    """Add the first argument of each call."""
+    """
+    Add the first argument of each task.
+
+    Marks the result of each task as the sum.
+    """
     from celery import current_app
 
     result = 0
@@ -22,9 +26,13 @@ def add(requests):
     return result
 
 
-@shared_task(base=Batches, flush_every=2, flush_interval=1)
+@shared_task(base=Batches, flush_every=2, flush_interval=0.1)
 def cumadd(requests):
-    """Calculate the cumulative sum of the first arguments of each call."""
+    """
+    Calculate the cumulative sum of the first argument of each task.
+
+    Marks the result of each task as the sum at the point.
+    """
     from celery import current_app
 
     result = 0

--- a/t/integration/test_batches.py
+++ b/t/integration/test_batches.py
@@ -72,8 +72,8 @@ def test_flush_interval(celery_app, celery_worker):
 
     result = add.delay(1)
 
-    # The flush interval is 1 second, this is longer.
-    sleep(2)
+    # The flush interval is 0.1 second, this is longer.
+    sleep(0.2)
 
     # Let the worker work.
     _wait_for_ping()


### PR DESCRIPTION
This shaves a few seconds off of each test run, which isn't huge but is an easy win.