### PR TITLE
Support custom `Request` classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,9 @@ Improvements
 ------------
 
 * Support passing multiple or keyword arguments by disabling Celery's ``typing``
-  feature for ``Batch`` tasks. (`#39 <https://github.com/clokep/celery-batches/pull/39>`_)
+  feature for ``Batches`` tasks. (`#39 <https://github.com/clokep/celery-batches/pull/39>`_)
+* Support [using a custom ``Request``](https://docs.celeryq.dev/en/stable/userguide/tasks.html)
+  for ``Batches`` tasks. (`#63 <https://github.com/clokep/celery-batches/pull/63>`_)
 
 Maintenance
 -----------
@@ -91,8 +93,8 @@ Maintenance
 Improvements
 ------------
 
-* Properly set the ``current_task`` when running ``Batch`` tasks. (`#4 <https://github.com/clokep/celery-batches/pull/4>`_)
-* Call the success signal after a successful run of the ``Batch`` task. (`#6 <https://github.com/clokep/celery-batches/pull/6>`_)
+* Properly set the ``current_task`` when running ``Batches`` tasks. (`#4 <https://github.com/clokep/celery-batches/pull/4>`_)
+* Call the success signal after a successful run of the ``Batches`` task. (`#6 <https://github.com/clokep/celery-batches/pull/6>`_)
 * Support running tasks eagerly via the ``Task.apply()`` method. This causes
   the task to execute with a batch of a single item. Contributed by
   `@scalen <https://github.com/scalen>`_. (`#16 <https://github.com/clokep/celery-batches/pull/16>`_,
@@ -135,7 +137,7 @@ Maintenance
 Improvements
 ------------
 
-* ``Batch`` tasks now call pre- and post-run signals.
+* ``Batches`` tasks now call pre- and post-run signals.
 
 Maintenance
 -----------

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,4 @@
 pytest-celery
 pytest~=6.2
 coverage
+pytest-timeout

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps=
 sitepackages = False
 recreate = False
 commands =
-    coverage run -m pytest
+    coverage run -m pytest --timeout=60
     coverage html
 setenv =
     redis: TEST_BROKER=redis://


### PR DESCRIPTION
The goal of this was mostly to test acking so the code could be simpified to be compatible with #62, but it morphed a little bit to add a new feature:

* Properly supports overriding the `Request` used for `Batches` tasks.
* Add tests for acking.
* Simplifies the code to avoid making useless lists (for #62). (It is included here since it is a larger change than just adding type hints.)