### PR TITLE
Support "hybrid" protocol 1 & 2 messages.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Improvements
   feature for ``Batches`` tasks. (`#39 <https://github.com/clokep/celery-batches/pull/39>`_)
 * Support |using a custom Request class|_ for ``Batches`` tasks.
   (`#63 <https://github.com/clokep/celery-batches/pull/63>`_)
+* Handle "hybrid" messages that have moved between Celery versions. Port
+  `celery/celery#4358 <https://github.com/celery/celery/pull/4358>`_ to celery-batches.
+  (`#64 <https://github.com/clokep/celery-batches/pull/64>`_)
 
 .. |using a custom Request class| replace:: using a custom ``Request`` class
 .. using a custom Request class: https://docs.celeryq.dev/en/stable/userguide/tasks.html

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,8 +13,15 @@ Improvements
   feature for ``Batches`` tasks. (`#39 <https://github.com/clokep/celery-batches/pull/39>`_)
 * Support |using a custom Request class|_ for ``Batches`` tasks.
   (`#63 <https://github.com/clokep/celery-batches/pull/63>`_)
+
+Bugfixes
+--------
+
 * Handle "hybrid" messages that have moved between Celery versions. Port
   `celery/celery#4358 <https://github.com/celery/celery/pull/4358>`_ to celery-batches.
+  (`#64 <https://github.com/clokep/celery-batches/pull/64>`_)
+* Fix task ETA issues when timezone is defined in configuration. Port
+  `celery/celery#3867 <https://github.com/celery/celery/pull/3867>`_ to celery-batches.
   (`#64 <https://github.com/clokep/celery-batches/pull/64>`_)
 
 .. |using a custom Request class| replace:: using a custom ``Request`` class


### PR DESCRIPTION
Ports celery/celery#4358.

This would likely be difficult to come across now since protocol 2 messages have been the default for a while, but it reduces the diff of the strategy between batches & the default strategy.