### PR TITLE
Include `request_dict` in `SimpleRequest`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,10 @@ next
 
 Improvements
 ------------
-* Support passing through the `request_dict` from the original Celery request
+
+* Support passing through the `request_dict` from the original Celery request.
+  Contributed by `@montasaurus <https://github.com/montasaurus>`_.
+  (`#71 <https://github.com/clokep/celery-batches/pull/71>`_)
 
 Maintenance
 -----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ Changelog
 next
 ====
 
+Improvements
+------------
+* Support passing through the `request_dict` from the original Celery request
+
 Maintenance
 -----------
 

--- a/celery_batches/__init__.py
+++ b/celery_batches/__init__.py
@@ -109,6 +109,9 @@ class SimpleRequest:
 
     #: used similarly to reply_to
     correlation_id = None
+    
+    #: includes all of the original request headers
+    request_dict = {}
 
     #: TODO
     chord = None
@@ -124,6 +127,7 @@ class SimpleRequest:
         ignore_result: bool,
         reply_to: Optional[str],
         correlation_id: Optional[str],
+        request_dict: Optional[dict],
     ):
         self.id = id
         self.name = name
@@ -134,6 +138,7 @@ class SimpleRequest:
         self.ignore_result = ignore_result
         self.reply_to = reply_to
         self.correlation_id = correlation_id
+        self.request_dict = request_dict
 
     @classmethod
     def from_request(cls, request: Request) -> "SimpleRequest":
@@ -151,6 +156,7 @@ class SimpleRequest:
             ignore_result,
             request.reply_to,
             request.correlation_id,
+            request.request_dict,
         )
 
 

--- a/celery_batches/__init__.py
+++ b/celery_batches/__init__.py
@@ -127,7 +127,7 @@ class SimpleRequest:
         ignore_result: bool,
         reply_to: Optional[str],
         correlation_id: Optional[str],
-        request_dict: Optional[dict],
+        request_dict: Optional[Dict[str, Any]],
     ):
         self.id = id
         self.name = name

--- a/celery_batches/__init__.py
+++ b/celery_batches/__init__.py
@@ -109,9 +109,9 @@ class SimpleRequest:
 
     #: used similarly to reply_to
     correlation_id = None
-    
+
     #: includes all of the original request headers
-    request_dict = {}
+    request_dict: Dict[str, Any] = {}
 
     #: TODO
     chord = None

--- a/celery_batches/__init__.py
+++ b/celery_batches/__init__.py
@@ -291,6 +291,7 @@ class Batches(Task):
             ignore_result=options.get("ignore_result", False),
             reply_to=None,
             correlation_id=None,
+            request_dict={},
         )
 
         return super().apply(([request],), {}, *_args, **options)

--- a/celery_batches/__init__.py
+++ b/celery_batches/__init__.py
@@ -111,7 +111,7 @@ class SimpleRequest:
     correlation_id = None
 
     #: includes all of the original request headers
-    request_dict: Dict[str, Any] = {}
+    request_dict: Optional[Dict[str, Any]] = {}
 
     #: TODO
     chord = None


### PR DESCRIPTION
This gives you access to the headers in the original request, which is helpful for extracting custom headers.