### PR TITLE
Fix pulling celery/kombu intersphinx mappings.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,6 +72,6 @@ texinfo_documents = [
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/dev/", None),
-    "kombu": ("https://docs.celeryq.dev/projects/kombu/en/master/", None),
-    "celery": ("https://docs.celeryq.dev/en/master/", None),
+    "kombu": ("https://docs.celeryq.dev/projects/kombu/en/main/", None),
+    "celery": ("https://docs.celeryq.dev/en/main/", None),
 }


### PR DESCRIPTION
The branch names were updated from `master` to `main`.