### PR TITLE
Drop support for Celery 4.4.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Maintenance
 
 * Support Celery 5.3. (`#68 <https://github.com/clokep/celery-batches/pull/68>`_,
   `#77 <https://github.com/clokep/celery-batches/pull/77>`_)
+* Drop support for Celery < 5.0. (`#78 <https://github.com/clokep/celery-batches/pull/78>`_)
 * Drop support for Python 3.7. (`#77 <https://github.com/clokep/celery-batches/pull/77>`_)
 
 0.7 (2022-05-02)

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ celery-batches version runs on,
 - Python (3.8, 3.9, 3.10)
 - PyPy3 (7.6)
 
-And is tested with Celery >= 4.4.
+And is tested with Celery >= 5.0.
 
 If you're running an older version of Python, you need to be running
 an older version of celery-batches:
@@ -46,6 +46,7 @@ an older version of celery-batches:
 
 - Celery < 4.0: Use `celery.contrib.batches` instead.
 - Celery 4.0 - 4.3: celery-batches 0.3.
+- Celery 4.4: celery-batches 0.7.
 
 History
 =======

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ project_urls =
 [options]
 packages =
     celery_batches
-install_requires = celery>=4.4,<5.3
+install_requires = celery>=5.0,<5.3
 python_requires = >=3.8
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {pypy3,3.8,3.9}-celery{44,50,51,52,master}-unit,
+    {pypy3,3.8,3.9}-celery{50,51,52,master}-unit,
     # Celery 5.2 added support for Python 3.10.
     3.10-celery{52,53,master}-unit,
     # Integration tests.
@@ -18,7 +18,6 @@ python =
 [testenv]
 deps=
     -r{toxinidir}/requirements/test.txt
-    celery44: celery>=4.4,<4.5
     celery50: celery>=5.0,<5.1
     celery51: celery>=5.1,<5.2
     # pypy3 seems to only have celery 5.2.0b3 available and not the final release.


### PR DESCRIPTION
Celery 4.4 was released in December 2019 and hasn't seen updates since July 2020. It was replaced with Celery 5.0 in Sept 2020.

The code should still work OK, but Celery 4.4 is no longer supported upstream and this reduces our testing matrix. Use celery-batches 0.7 if you still need to support Celery 4.4.