### PR TITLE
chore(celery): add support for Celery 5.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ project_urls =
 [options]
 packages =
     celery_batches
-install_requires = celery>=5.0,<5.3
+install_requires = celery>=5.0,<5.4
 python_requires = >=3.8
 
 [flake8]


### PR DESCRIPTION
In https://github.com/clokep/celery-batches/pull/75, I added CI runs against Celery 5.3 but forgot to declare Celery 5.3 compatibility in `setup.cfg`, I'm a failure :sweat_smile: 