### PR TITLE
Remove upper constraint for `celery`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ Changelog
 next
 ====
 
+Packaging
+---------
+
+- Remove upper version constraint on ``celery`` package. (`#89 <https://github.com/clokep/celery-batches/pull/89>`_)
+
 Improvements
 ------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ project_urls =
 [options]
 packages =
     celery_batches
-install_requires = celery>=5.0,<5.4
+install_requires = celery>=5.0
 python_requires = >=3.8
 
 [flake8]


### PR DESCRIPTION
Fixes #88 to verify usability with celery 5.4+.