### PR TITLE
Limit pytest-celery version to 0.0.0

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
-pytest-celery
+pytest-celery~=0.0.0
 pytest~=6.2
 coverage
 pytest-timeout


### PR DESCRIPTION
See the errors in #86.