### PR TITLE
Reset counter after processing requests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,12 @@ Changelog
 next
 ====
 
+Bugfixes
+--------
+
+* Fix installing resetting the count of pending tasks when flushing tasks due to
+  the flush interval being reached. (`#95 <https://github.com/clokep/celery-batches/pull/95>`_)
+
 Improvements
 ------------
 

--- a/celery_batches/__init__.py
+++ b/celery_batches/__init__.py
@@ -342,7 +342,7 @@ class Batches(Task):
         if len(ready_requests) > 0:
             logger.debug("Batches: Ready buffer complete: %s", len(ready_requests))
             self.flush(ready_requests)
-            self._count = count(1)
+            self._count = count(self._pending.qsize() + 1)
 
         if not ready_requests and self._pending.qsize() == 0:
             logger.debug("Batches: Canceling timer: Nothing in buffers.")

--- a/t/integration/test_batches.py
+++ b/t/integration/test_batches.py
@@ -109,7 +109,7 @@ def test_flush_interval_resets_counter(
     if not celery_app.conf.broker_url.startswith("memory"):
         raise pytest.skip("Flaky on live brokers")
 
-    result1 = add.delay(1)
+    result_1 = add.delay(1)
 
     # The flush interval is 0.1 second, this is longer.
     sleep(2)
@@ -117,16 +117,16 @@ def test_flush_interval_resets_counter(
     # Let the worker work.
     _wait_for_ping()
 
-    assert result1.get() == 1
+    assert result_1.get() == 1
 
     # Run next task, it should not execute as counter was reset
-    result2 = add.delay(2)
+    result_2 = add.delay(2)
 
     # The flush interval is 0.1 second, this is shorter.
     sleep(0.01)
     _wait_for_ping()
 
-    assert result2.state == states.PENDING
+    assert result_2.state == states.PENDING
 
 
 def test_flush_calls(celery_worker: TestWorkController) -> None:


### PR DESCRIPTION
In current implementation, when flush is caused by time interval, the counter does not reset, so if i set flush_every=2 and schedule 1 task and then it is processed after time interval, scheduling next task immediately after causes processing to trigger. It would make more logical sense to trigger only after 2 message occur again.