### PR TITLE
Support Celery 5.5 & Python 3.13; drop support for Python 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: "actions/setup-python@v3"
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: "Install dependencies"
         run: python -m pip install -r requirements/pkgutils.txt
@@ -47,7 +47,7 @@ jobs:
 
       - uses: "actions/setup-python@v3"
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: "Install dependencies"
         run: |
@@ -66,7 +66,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10", "pypy-3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,10 @@ Improvements
 Maintenance
 -----------
 
+* Support Celery 5.5.
 * Drop support for Celery < 5.2. (`#92 <https://github.com/clokep/celery-batches/pull/92>`_)
+* Support Python 3.13.
+* Drop support for Python 3.8.
 
 
 0.9 (2024-06-03)

--- a/README.rst
+++ b/README.rst
@@ -27,19 +27,21 @@ What do I need?
 
 celery-batches version runs on,
 
-- Python (3.8, 3.9, 3.10, 3.11, 3.12)
-- PyPy3 (7.6)
+- Python (3.9, 3.10, 3.11, 3.12, 3.13)
+- PyPy (3.10, 3.11)
 
 And is tested with Celery ~= 5.0.
 
 If you're running an older version of Python, you need to be running
-an older version of celery-batches:
+an older version of celery-batches, the last version supporting each
+Python version is listed below:
 
 - Python 2.7: celery-batches 0.3.
 - Python 3.4: celery-batches 0.2.
 - Python 3.5: celery-batches 0.3.
 - Python 3.6: celery-batches 0.5.
 - Python 3.7: celery-batches 0.7.
+- Python 3.8: celery-batches 0.9.
 
 If you're running an older version of Celery, you need to be running
 an older version of celery-batches:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,11 +18,11 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Operating System :: OS Independent
@@ -36,8 +36,8 @@ project_urls =
 [options]
 packages =
     celery_batches
-install_requires = celery>=5.0,<5.5
-python_requires = >=3.8
+install_requires = celery>=5.0,<5.6
+python_requires = >=3.9
 
 [flake8]
 extend-ignore = E203

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
 envlist =
-    {pypy3,3.8,3.9,3.10}-celery{52,main}-unit,
+    {pypy3,3.9,3.10}-celery{52,main}-unit,
     # Celery 5.3 added support for Python 3.11.
     3.11-celery{53,main}-unit,
     # Celery 5.4 added support for Python 3.12.
     3.12-celery{54,main}-unit,
+    # Celery 5.5 added support for Python 3.13.
+    3.13-celery{55,main}-unit,
     # Integration tests.
     3.10-celery52-integration-{rabbitmq,redis},
     flake8
@@ -13,11 +15,11 @@ isolated_build = True
 [gh-actions]
 python =
     pypy-3: pypy3
-    3.8: 3.8
     3.9: 3.9
     3.10: 3.10
     3.11: 3.11
     3.12: 3.12
+    3.13: 3.13
 
 [testenv]
 deps=
@@ -25,6 +27,7 @@ deps=
     celery52: celery>=5.2.0,<5.3
     celery53: celery>=5.3.0,<5.4
     celery54: celery>=5.4.0,<5.5
+    celery55: celery>=5.5.0,<5.6
     celerymain: https://codeload.github.com/celery/celery/zip/main
 
     # By default celery (via kombu) install py-amqp.


### PR DESCRIPTION
Fixes #96 