### PR TITLE
Relax Celery version constraint to allow any 5.X version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ project_urls =
 [options]
 packages =
     celery_batches
-install_requires = celery>=5.0,<5.6
+install_requires = celery>=5.0,<6
 python_requires = >=3.9
 
 [flake8]


### PR DESCRIPTION
Celery 5.6 was released a few days ago, but celery-batches' constraints doesn't accept it. No breaking change expected, celery-batches already requires python 3.9+.