### PR TITLE
Drop python 3.9 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: "actions/setup-python@v3"
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: "Install dependencies"
         run: python -m pip install -r requirements/pkgutils.txt
@@ -47,7 +47,7 @@ jobs:
 
       - uses: "actions/setup-python@v3"
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: "Install dependencies"
         run: |
@@ -66,7 +66,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.10", "pypy-3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.10", "pypy-3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@
 Changelog
 #########
 
+next
+====
+
+Maintenance
+-----------
+
+* Drop support for Python 3.9 (`#106 <https://github.com/clokep/celery-batches/pull/106>`_)
+
 2026-01-16
 ==========
 

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ What do I need?
 
 celery-batches version runs on,
 
-- Python (3.9, 3.10, 3.11, 3.12, 3.13, 3.14)
+- Python (3.10, 3.11, 3.12, 3.13, 3.14)
 - PyPy (3.10, 3.11)
 
 And is tested with Celery ~= 5.0.
@@ -42,6 +42,7 @@ Python version is listed below:
 - Python 3.6: celery-batches 0.5.
 - Python 3.7: celery-batches 0.7.
 - Python 3.8: celery-batches 0.9.
+- Python 3.9: celery-batches 0.11.
 
 If you're running an older version of Celery, you need to be running
 an older version of celery-batches:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ license = "BSD-3-Clause"
 version = "0.11"
 description = "Experimental task class that buffers messages and processes them as a list."
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "celery>=5.0,<5.7",
 ]
@@ -19,7 +19,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {pypy3,3.9,3.10}-celery{52,main}-unit,
+    {pypy3,3.10}-celery{52,main}-unit,
     # Celery 5.3 added support for Python 3.11.
     3.11-celery{53,main}-unit,
     # Celery 5.4 added support for Python 3.12.
@@ -17,7 +17,6 @@ isolated_build = True
 [gh-actions]
 python =
     pypy-3: pypy3
-    3.9: 3.9
     3.10: 3.10
     3.11: 3.11
     3.12: 3.12


### PR DESCRIPTION
## What

Celery dropped support for 3.9 on their main branch, and the test suite of this repo depends that each version should work on the main branch. 

This MR drops support for it to unblock further pull requests